### PR TITLE
fix role in controller

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -4,16 +4,26 @@ import jwt from 'jsonwebtoken';
 
 export const registerUser = async (req, res) => {
   try {
-    const { username, email, password } = req.body;
-    const existingUser = await User.findOne({ email });
+    const { username, email, password, role } = req.body;
+    const existingUser = await User.findOne({
+      $or: [{ email }, { username }] 
+    });
     if (existingUser) {
       return res.status(400).json({ message: 'User already exists.' });
     }
 
-    const user = new User({ username, email, password });
+    const user = new User({
+      username, 
+      email, 
+      password,
+      role: role === 'admin' ? 'admin' : 'user'
+    });
+
     await user.save();
 
-    res.status(201).json({ message: 'User registered successfully', user });
+    const savedUser = await User.findById(user._id).select('-password');
+
+    res.status(201).json({ message: 'User registered successfully', user: savedUser });
   } catch (error) {
     res.status(500).json({ message: 'Error registering user', error: error.message });
   }


### PR DESCRIPTION
In this commit I updated the registerUser in usercontroller to accept an optional role field from the request body.
I added a uniqueness check for both email and username using MongoDBs $or operator to prevent duplicates.
The role is now set to "admin" only if explicitly provided as admin. Otherwise it defaults to user, allowing admins to create other admins.